### PR TITLE
Fixed JsonMappingException when subclassing a bean with nested objects

### DIFF
--- a/src/main/resources/templates/bean.ftl
+++ b/src/main/resources/templates/bean.ftl
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ${beanName} implements ${type.name}<#if isRoot>, DynamapRecordBean<${type.name}></#if> {
@@ -36,6 +37,9 @@ public class ${beanName} implements ${type.name}<#if isRoot>, DynamapRecordBean<
     <#list type.fields as field>
     <#if field.isSerialize()>
     @JsonProperty(${field.name?upper_case}_FIELD)
+    </#if>
+    <#if field.isGeneratedType()>
+    @JsonDeserialize(as=<@field_type field=field />Bean.class)
     </#if>
     private <@field_type field=field /> ${field.name};
     </#list>

--- a/src/test/java/com/n3twork/dynamap/DynamapTest.java
+++ b/src/test/java/com/n3twork/dynamap/DynamapTest.java
@@ -364,4 +364,23 @@ public class DynamapTest {
         Assert.assertTrue(savedExampleDocsIds.containsAll(exampleDocsIds) && exampleDocsIds.containsAll(savedExampleDocsIds));
         Assert.assertTrue(savedDummyDocsIds.containsAll(dummyDocsIds) && dummyDocsIds.containsAll(savedDummyDocsIds));
     }
+
+    @Test
+    public void testBeanSubclass() {
+        String exampleId1 = UUID.randomUUID().toString();
+        String nestedId1 = UUID.randomUUID().toString();
+
+        NestedTypeBean nestedObject = new NestedTypeBean().setId(nestedId1).setBio("biography");
+
+        ExampleDocumentBean doc = new ExampleDocumentBean().setExampleId(exampleId1).setSequence(1)
+                .setSomeList(Arrays.asList("test1", "test2")).setNestedObject(nestedObject).setAlias("alias");
+        dynamap.save(doc, null);
+
+        GetObjectRequest<ExampleDocumentBeanSubclass> getObjectRequest = new GetObjectRequest<>(ExampleDocumentBeanSubclass.class).withHashKeyValue(exampleId1).withRangeKeyValue(1);
+        ExampleDocumentBeanSubclass exampleDocumentBean = dynamap.getObject(getObjectRequest, null);
+
+        Assert.assertNotNull(exampleDocumentBean.getExampleId(), exampleId1);
+        nestedObject = new NestedTypeBean(exampleDocumentBean.getNestedObject());
+        Assert.assertEquals(nestedObject.getId(), nestedId1);
+    }
 }

--- a/src/test/java/com/n3twork/dynamap/ExampleDocumentBeanSubclass.java
+++ b/src/test/java/com/n3twork/dynamap/ExampleDocumentBeanSubclass.java
@@ -1,0 +1,7 @@
+package com.n3twork.dynamap;
+
+import com.n3twork.dynamap.test.ExampleDocumentBean;
+
+public class ExampleDocumentBeanSubclass extends ExampleDocumentBean  {
+
+}


### PR DESCRIPTION
We have several classes that inherits from bean classes to add extra functionality.
And the following error happens when trying to read such an object with `dynamap.getObject`.

`Group` inherits from `GroupBean` which has `gnms` nested object:

`com.fasterxml.jackson.databind.JsonMappingException: Can not construct instance of com.n3twork.nw.datamodel.generated.GroupNameMembers: abstract types either need to be mapped to concrete types, have custom deserializer, or contain additional type information
at [Source: N/A; line: -1, column: -1] (through reference chain: com.n3twork.nw.datamodel.domain.Group["gnms"])`