### PR TITLE
Fix increment methods double-incrementing when called for the first time

### DIFF
--- a/src/main/resources/templates/updates.ftl
+++ b/src/main/resources/templates/updates.ftl
@@ -420,14 +420,14 @@ public class ${updatesName} implements ${type.name}, <#if isRoot>Record</#if>Upd
     }
     <#if field.isNumber()>
     public ${updatesName} increment${field.name?cap_first}(${field.elementType} amount) {
-        ${field.name}Delta = (${field.name}Delta == null ? amount: ${field.name}Delta) + amount;
+        ${field.name}Delta = ${field.name}Delta == null ? amount : (${field.name}Delta + amount);
         modified = true;
         ${field.name}Modified = true;
         <@persisted_modified field/>
         return this;
     }
     public ${updatesName} decrement${field.name?cap_first}(${field.elementType} amount) {
-        ${field.name}Delta = (${field.name}Delta == null ? amount : ${field.name}Delta) - amount;
+        ${field.name}Delta = ${field.name}Delta == null ? amount : (${field.name}Delta - amount);
         modified = true;
         ${field.name}Modified = true;
         <@persisted_modified field/>

--- a/src/test/java/com/n3twork/dynamap/DynamapTest.java
+++ b/src/test/java/com/n3twork/dynamap/DynamapTest.java
@@ -409,6 +409,23 @@ public class DynamapTest {
     }
 
     @Test
+    public void testIncrementIntegerField() {
+        String docId = UUID.randomUUID().toString();
+        TestDocumentBean doc = new TestDocumentBean(docId, 1);
+
+        dynamap.save(new SaveParams<>(doc));
+
+        TestDocumentUpdates updates = doc.createUpdates();
+        updates.incrementIntegerField(1);
+
+        dynamap.update(new UpdateParams<>(updates));
+
+        TestDocument saved = dynamap.getObject(new GetObjectParams<>(new GetObjectRequest<>(TestDocumentBean.class).withHashKeyValue(docId).withRangeKeyValue(1)));
+
+        Assert.assertEquals((int) saved.getIntegerField(), 1);
+    }
+
+    @Test
     public void testPersistDisabled() {
         NestedTypeBean nestedTypeBean = createNestedTypeBean();
         nestedTypeBean.setNotPersistedString("foo");


### PR DESCRIPTION
If a number field has a default value of 0 then the generated increment/decrement methods were double-increment/decrementing when called for the first time.