### PR TITLE
Support parallel scans

### DIFF
--- a/src/main/java/com/n3twork/dynamap/Dynamap.java
+++ b/src/main/java/com/n3twork/dynamap/Dynamap.java
@@ -417,6 +417,12 @@ public class Dynamap {
                 scanspec.withExclusiveStartKey(tableDefinition.getHashKey(), scanRequest.getStartExclusiveHashKeyValue());
             }
         }
+
+        if (scanRequest.getTotalSegments() != null && scanRequest.getSegment() != null) {
+            scanspec.withSegment(scanRequest.getSegment());
+            scanspec.withTotalSegments(scanRequest.getTotalSegments());
+        }
+
         if (scanRequest.getMaxResultSize() != null) {
             scanspec.withMaxResultSize(scanRequest.getMaxResultSize());
         }
@@ -485,7 +491,7 @@ public class Dynamap {
             }
         };
 
-        return new ScanResult(itemIterator);
+        return new ScanResult<>(itemIterator);
     }
 
     public void save(SaveParams saveParams) {

--- a/src/main/java/com/n3twork/dynamap/ScanRequest.java
+++ b/src/main/java/com/n3twork/dynamap/ScanRequest.java
@@ -29,6 +29,8 @@ public class ScanRequest<T> {
     private DynamoRateLimiter readRateLimiter;
     private String startExclusiveHashKeyValue;
     private Object startExclusiveRangeKeyValue;
+    private Integer segment;
+    private Integer totalSegments;
     private Object migrationContext;
     private Integer maxResultSize;
     private Integer maxPageSize;
@@ -85,6 +87,16 @@ public class ScanRequest<T> {
         return this;
     }
 
+    public ScanRequest<T> withSegment(Integer segment) {
+        this.segment = segment;
+        return this;
+    }
+
+    public ScanRequest<T> withTotalSegments(Integer totalSegments) {
+        this.totalSegments = totalSegments;
+        return this;
+    }
+
     public ScanRequest<T> withMaxResultSize(Integer maxResultSize) {
         this.maxResultSize = maxResultSize;
         return this;
@@ -132,6 +144,14 @@ public class ScanRequest<T> {
 
     public Object getStartExclusiveRangeKeyValue() {
         return startExclusiveRangeKeyValue;
+    }
+
+    public Integer getSegment() {
+        return segment;
+    }
+
+    public Integer getTotalSegments() {
+        return totalSegments;
     }
 
     public Object getMigrationContext() {


### PR DESCRIPTION
Support parallel scans by adding segment and total segment parameters to ScanRequest.