### PR TITLE
Custom exception for unsupported schema

### DIFF
--- a/src/main/java/com/n3twork/dynamap/DynamapLoadService.java
+++ b/src/main/java/com/n3twork/dynamap/DynamapLoadService.java
@@ -131,7 +131,7 @@ class DynamapLoadService {
         }
 
         if (currentVersion > tableDefinition.getVersion()) {
-            throw new RuntimeException("Document schema has been migrated to a version later than this release supports: Document version: " + currentVersion + ", Supported version: " + tableDefinition.getVersion());
+            throw new UnsupportedSchemaVersionException("Document schema has been migrated to a version later than this release supports: Document version: " + currentVersion + ", Supported version: " + tableDefinition.getVersion());
         }
 
         if (currentVersion < tableDefinition.getVersion()) {

--- a/src/main/java/com/n3twork/dynamap/UnsupportedSchemaVersionException.java
+++ b/src/main/java/com/n3twork/dynamap/UnsupportedSchemaVersionException.java
@@ -1,0 +1,8 @@
+package com.n3twork.dynamap;
+
+public class UnsupportedSchemaVersionException extends RuntimeException {
+
+    public UnsupportedSchemaVersionException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/com/n3twork/dynamap/DynamapTest.java
+++ b/src/test/java/com/n3twork/dynamap/DynamapTest.java
@@ -667,6 +667,7 @@ public class DynamapTest {
         } catch (Exception e) {
             exceptionThrown = true;
             Assert.assertTrue(e.getMessage().contains("Document schema has been migrated to a version later than this release supports"));
+            Assert.assertTrue(e instanceof UnsupportedSchemaVersionException);
         }
         Assert.assertTrue(exceptionThrown);
 


### PR DESCRIPTION
There are cases where we might wan to implement special handling the exception that is thrown when a later schema version is encountered e.g. translating the exception to something that tells the client to retry. We could check the exception message but we might as well have our own exception type for this.