### PR TITLE
WriteTx.save takes a SaveParams instead of a raw bean.

### DIFF
--- a/src/main/java/com/n3twork/dynamap/WriteTx.java
+++ b/src/main/java/com/n3twork/dynamap/WriteTx.java
@@ -65,8 +65,18 @@ public class WriteTx {
         updates.add(writeOpFactory.buildUpdate(u));
     }
 
+    /**
+     * This method is deprecated: use save(SaveParams<T>) instead.
+     * @param dynamapRecordBean
+     * @param <T>
+     */
+    @Deprecated
     public <T extends DynamapRecordBean> void save(T dynamapRecordBean) {
         puts.add(writeOpFactory.buildPut(dynamapRecordBean, dynamoItemFactory));
+    }
+
+    public <T extends DynamapRecordBean> void save(SaveParams<T> saveParams) {
+        puts.add(writeOpFactory.buildPut(saveParams, dynamoItemFactory));
     }
 
     public void delete(DeleteRequest deleteRequest) {


### PR DESCRIPTION
This is an API fix for `WriteTx`: we need to pass a `SaveParams` instance so we can specify behaviors (e.g. `disableOverwrite`) along with the bean we want to save. The `WriteTx.save(Bean)` call has been deprecated.