### PR TITLE
A fix and cleanup for TransactionCancelledExceptions

### DIFF
--- a/src/test/java/com/n3twork/dynamap/DynamapTxTest.java
+++ b/src/test/java/com/n3twork/dynamap/DynamapTxTest.java
@@ -157,17 +157,15 @@ public class DynamapTxTest {
         // Player exists, so this second save should fail with when we disable overwriting
         WriteTx secondCreateTx = dynamap.newWriteTx();
         secondCreateTx.save(new SaveParams<>(p1).withDisableOverwrite(true));
-        RuntimeException thrown = null;
+        TransactionCanceledException thrown = null;
         try {
             secondCreateTx.exec();
-        } catch(RuntimeException e) {
+        } catch(TransactionCanceledException e) {
             thrown = e;
         }
         assertNotNull(thrown);
-        assertEquals(thrown.getCause().getClass(), TransactionCanceledException.class);
-        TransactionCanceledException tce = (TransactionCanceledException) thrown.getCause();
-        assertEquals(tce.getCancellationReasons().size(), 1);
-        assertEquals(tce.getCancellationReasons().get(0).getCode(), "ConditionalCheckFailed");
+        assertEquals(thrown.getCancellationReasons().size(), 1);
+        assertEquals(thrown.getCancellationReasons().get(0).getCode(), "ConditionalCheckFailed");
 
         // Overwrite will work when we don't explicitly disable overwriting
         WriteTx thirdCreateTx = dynamap.newWriteTx();


### PR DESCRIPTION
1. BugFix: present `TransactWriteItems` to DynamoDB in the order they were requested by the caller. This is important in case of errors so the list of `TransactionCancelledException.CancellationReasons` can be linked to the write request that failed.
2. Don't wrap `TransactionCancelledException` in a `RuntimException`, it already is a `RuntimeException`