### PR TITLE
Fix clearing for list collections with deltas enabled.

### DIFF
--- a/src/main/resources/templates/updates.ftl
+++ b/src/main/resources/templates/updates.ftl
@@ -584,7 +584,11 @@ public class ${updatesName} implements ${type.name}, <#if isRoot>Record</#if>Upd
 
         <#elseif field.type == 'List'>
             <#if field.useDeltas() && !field.isCompressCollection()>
-                expression.addValuesToList(parentDynamoFieldName, "${field.dynamoName}", ${field.name}Adds, ${field.elementType}.class);
+                if (${field.name}Clear) {
+                    expression.setMultiValue(parentDynamoFieldName, "${field.dynamoName}", Collections.emptyList(), ${field.elementType}.class);
+                } else {
+                    expression.addValuesToList(parentDynamoFieldName, "${field.dynamoName}", ${field.name}Adds, ${field.elementType}.class);
+                }
             <#else>
                 <#if field.isCompressCollection()>
                 expression.setValue(parentDynamoFieldName, "${field.dynamoName}", GZipUtil.serialize(get${field.name?cap_first}(), expression.getObjectMapper()));

--- a/src/test/java/com/n3twork/dynamap/DynamapTest.java
+++ b/src/test/java/com/n3twork/dynamap/DynamapTest.java
@@ -459,6 +459,13 @@ public class DynamapTest {
         dynamap.update(new UpdateParams<>(updates));
         doc = dynamap.getObject(createGetObjectParams(doc));
         Assert.assertEquals(doc.getListOfInteger().size(), 3);
+
+        updates = doc.createUpdates();
+        updates.clearListOfInteger();
+        Assert.assertEquals(updates.getListOfInteger().size(), 0);
+        dynamap.update(new UpdateParams<>(updates));
+        doc = dynamap.getObject(createGetObjectParams(doc));
+        Assert.assertEquals(doc.getListOfInteger().size(), 0);
     }
 
     @Test


### PR DESCRIPTION
I could alternatively add a `boolean clear` parameter to `DynamoExpressionBuilder.addValuesToList`, to mimic the way clearing is implemented for `Map`-type attributes in `DynamoExpressionBuilder.updateMap` ([link](https://github.com/N3TWORK/dynamap/blob/952ed0e/src/main/java/com/n3twork/dynamap/DynamoExpressionBuilder.java#L156)).