### PR TITLE
Hs/binarysupport

### DIFF
--- a/src/main/java/com/n3twork/dynamap/CodeGenerator.java
+++ b/src/main/java/com/n3twork/dynamap/CodeGenerator.java
@@ -36,7 +36,7 @@ public class CodeGenerator {
     private static final String OPT_SCHEMA_FILE_PATH = "schema";
     private static final String OPT_OUTPUT_PATH = "output";
 
-    private static final Set<String> BUILT_IN_TYPES = Sets.newHashSet("Integer", "Long", "Boolean", "Float", "Double", "String", "Map", "List", "Set");
+    private static final Set<String> BUILT_IN_TYPES = Sets.newHashSet("Integer", "Long", "Boolean", "Float", "Double", "String", "Map", "List", "Set", "byte[]");
 
     private final Configuration cfg;
 

--- a/src/main/java/com/n3twork/dynamap/model/TableDefinition.java
+++ b/src/main/java/com/n3twork/dynamap/model/TableDefinition.java
@@ -47,7 +47,7 @@ public class TableDefinition {
 
     @JsonCreator
     public TableDefinition(@JsonProperty("table") String tableName, @JsonProperty("description") String description, @JsonProperty("package") String packageName, @JsonProperty("type") String type, @JsonProperty("hashKey") String hashKey, @JsonProperty("rangeKey") String rangeKey,
-                           @JsonProperty("version") int version, @JsonProperty("fields") List<Field> fields, @JsonProperty("types") List<Type> types, @JsonProperty("globalSecondaryIndexes") List<Index> globalSecondaryIndexes, @JsonProperty("localSecondaryIndexes") List<Index> localSecondaryIndexes, @JsonProperty("optimisticLocking") boolean optimisticLocking,
+                           @JsonProperty("version") int version, @JsonProperty("types") List<Type> types, @JsonProperty("globalSecondaryIndexes") List<Index> globalSecondaryIndexes, @JsonProperty("localSecondaryIndexes") List<Index> localSecondaryIndexes, @JsonProperty("optimisticLocking") boolean optimisticLocking,
                            @JsonProperty("schemaVersionField") String schemaVersionField, @JsonProperty("enableMigrations") Boolean enableMigrations) {
         this.tableName = tableName;
         this.description = description;

--- a/src/test/resources/TestSchema.json
+++ b/src/test/resources/TestSchema.json
@@ -191,6 +191,12 @@
               "dynamoName": "ttl",
               "type": "ttl",
               "description": "A ttl field's DynamoDB type is Number. Its value is an epoch timestamp in seconds."
+            },
+            {
+              "name": "BLOB",
+              "dynamoName": "blob",
+              "type": "byte[]",
+              "description": "A Binary object. Might be used to store a serialized object instance."
             }
           ]
         },


### PR DESCRIPTION
This PR adds support for `byte[]` as a built-in type for Dynamap. The change is quite simple and required little more than including `byte[]` in the code generator's list of built-in types.
Fortunately, DynamoDB's `Item` class already detects and correctly handles `byte[]` fields in `public Item with(String attrName, Object val)`, so no other code changes were necessary.
Simple test cases included.