### PR TITLE
Use correct key names for transactions

### DIFF
--- a/src/main/java/com/n3twork/dynamap/TxUtil.java
+++ b/src/main/java/com/n3twork/dynamap/TxUtil.java
@@ -13,9 +13,11 @@ class TxUtil {
      */
     static Map<String, AttributeValue> getKey(TableDefinition tableDefinition, String hashKeyValue, Object rangeKeyValue) {
         Map<String, AttributeValue> key = new HashMap<>();
-        key.put(tableDefinition.getHashKey(), new AttributeValue(hashKeyValue));
+        String hashKeyFieldName = tableDefinition.getField(tableDefinition.getHashKey()).getDynamoName();
+        key.put(hashKeyFieldName, new AttributeValue(hashKeyValue));
         if (null != tableDefinition.getRangeKey()) {
-            key.put(tableDefinition.getRangeKey(), ItemUtils.toAttributeValue(rangeKeyValue));
+            String rangeKeyFieldName = tableDefinition.getField(tableDefinition.getRangeKey()).getDynamoName();
+            key.put(rangeKeyFieldName, ItemUtils.toAttributeValue(rangeKeyValue));
         }
         return key;
     }

--- a/src/test/resources/PlayerSchema.json
+++ b/src/test/resources/PlayerSchema.json
@@ -21,12 +21,12 @@
             {
               "name": "id",
               "description": "Player Id",
-              "dynamoName": "id",
+              "dynamoName": "i",
               "type": "String"
             },
             {
               "name": "name",
-              "dynamoName": "name",
+              "dynamoName": "n",
               "type": "String"
             }
           ]


### PR DESCRIPTION
Transactions using Dynamap were not working when the Dynamo hash/range key field names did not match the Java hash/range key field names. This fix ensures that the keys used in transactions are generated by referring to the table definition to look up the Dynamo field names.