### PR TITLE
BugFix: TableDefinition.getTableName breaks when prefix is not provided

### DIFF
--- a/src/main/java/com/n3twork/dynamap/model/TableDefinition.java
+++ b/src/main/java/com/n3twork/dynamap/model/TableDefinition.java
@@ -81,15 +81,7 @@ public class TableDefinition {
 
     @JsonIgnore
     public String getTableName(String prefix, String suffix) {
-        String fullTableName = "";
-        if (prefix != null) {
-            fullTableName = prefix + tableName;
-        }
-        if (suffix != null) {
-            fullTableName += suffix;
-        }
-
-        return fullTableName;
+        return TableUtil.getTableName(tableName, prefix, suffix);
     }
 
     public String getPackageName() {

--- a/src/main/java/com/n3twork/dynamap/model/TableUtil.java
+++ b/src/main/java/com/n3twork/dynamap/model/TableUtil.java
@@ -1,0 +1,15 @@
+package com.n3twork.dynamap.model;
+
+public class TableUtil {
+
+    public static String getTableName(String tableName, String prefix, String suffix) {
+        String result = tableName;
+        if (prefix != null) {
+            result = prefix + result;
+        }
+        if (suffix != null) {
+            result += suffix;
+        }
+        return result;
+    }
+}

--- a/src/test/java/com/n3twork/dynamap/model/TableUtilTest.java
+++ b/src/test/java/com/n3twork/dynamap/model/TableUtilTest.java
@@ -1,0 +1,29 @@
+package com.n3twork.dynamap.model;
+
+import org.testng.annotations.Test;
+
+import static com.n3twork.dynamap.model.TableUtil.getTableName;
+import static org.testng.Assert.assertEquals;
+
+public class TableUtilTest {
+
+    @Test
+    public void noPrefixNoSuffix() {
+        assertEquals(getTableName("tableName", null, null), "tableName");
+    }
+
+    @Test
+    public void withPrefix() {
+        assertEquals(getTableName("tableName", "prefix.", null), "prefix.tableName");
+    }
+
+    @Test
+    public void withSuffix() {
+        assertEquals(getTableName("tableName", null, ".suffix"), "tableName.suffix");
+    }
+
+    @Test
+    public void withPrefixAndSuffix() {
+        assertEquals(getTableName("tableName", "prefix.", ".suffix"), "prefix.tableName.suffix");
+    }
+}


### PR DESCRIPTION
Small fix and test case to make sure `TableDefinition.getTableName` works when no prefix is provided.

It was broken for the following cases:
`getTableName(null, "suffix")` -> returns "suffix"
`getTableName(null, null)` -> returns ""

(So it was only working when `prefix` was provided)
