### PR TITLE
hs/fixnotequals

### DIFF
--- a/src/main/java/com/n3twork/dynamap/DynamoExpressionBuilder.java
+++ b/src/main/java/com/n3twork/dynamap/DynamoExpressionBuilder.java
@@ -48,7 +48,8 @@ public class DynamoExpressionBuilder {
 
     public enum ComparisonOperator {
 
-        EQUALS("="), NOT_EQUALS("!="), LESS_THAN("<"), LESS_THAN_EQUAL_TO("<="), GREATHER_THAN(">"), GREATER_THAN_EQUAL_TO(">=");
+        // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html
+        EQUALS("="), NOT_EQUALS("<>"), LESS_THAN("<"), LESS_THAN_EQUAL_TO("<="), GREATHER_THAN(">"), GREATER_THAN_EQUAL_TO(">=");
 
         private final String value;
 


### PR DESCRIPTION
There is no `!=` comparator in DynamoDB, the correct one for `NOT EQUALS` is `<>`. I've patched that in our code and added a simple test to make sure it works.

https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html