### PR TITLE
Codegen fix for schemas with `enableMigrations: false`. Removes a con…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,6 +299,8 @@
                                 <argument>${project.basedir}/src/test/resources/DummyLocalIndexSchema.json</argument>
                                 <argument>--schema</argument>
                                 <argument>${project.basedir}/src/test/resources/PlayerSchema.json</argument>
+                                <argument>--schema</argument>
+                                <argument>${project.basedir}/src/test/resources/NoMigrationSchema.json</argument>
                                 <argument>--output</argument>
                                 <argument>${project.build.directory}/generated-test-sources</argument>
                             </arguments>

--- a/src/main/resources/templates/updates.ftl
+++ b/src/main/resources/templates/updates.ftl
@@ -649,7 +649,9 @@ public class ${updatesName} implements ${type.name}, <#if isRoot>Record</#if>Upd
     </#list>
 
     // Conditional expression
-    expression.addCheckFieldValueCondition(null, "${schemaVersionFieldName}", ${rootType}.SCHEMA_VERSION, DynamoExpressionBuilder.ComparisonOperator.EQUALS);
+    <#if isRoot && tableDefinition.isEnableMigrations()>
+            expression.addCheckFieldValueCondition(null, "${schemaVersionFieldName}", ${rootType}.SCHEMA_VERSION, DynamoExpressionBuilder.ComparisonOperator.EQUALS);
+    </#if>
     <#if isRoot && optimisticLocking>
             if (!disableOptimisticLocking && ${currentState}.getRevision() > 0) {
                 expression.addCheckFieldValueCondition(null, "${revisionFieldName}", ${currentState}.getRevision(), DynamoExpressionBuilder.ComparisonOperator.EQUALS);

--- a/src/test/java/com/n3twork/dynamap/DynamapTest.java
+++ b/src/test/java/com/n3twork/dynamap/DynamapTest.java
@@ -77,7 +77,8 @@ public class DynamapTest {
     public void setup() {
         schemaRegistry = new SchemaRegistry(getClass().getResourceAsStream("/TestSchema.json"),
                 getClass().getResourceAsStream("/DummySchema.json"),
-                getClass().getResourceAsStream("/DummyLocalIndexSchema.json"));
+                getClass().getResourceAsStream("/DummyLocalIndexSchema.json"),
+                getClass().getResourceAsStream("/NoMigrationSchema.json"));
         // Create tables
         dynamap = new Dynamap(ddb, schemaRegistry).withPrefix("test").withObjectMapper(objectMapper);
         dynamap.createTables(System.getProperty("aws.profile") == null, 10, 10);
@@ -1595,6 +1596,43 @@ public class DynamapTest {
         testDocumentBean.setBLOB(null);
         updated = dynamap.update(new UpdateParams<>(testDocumentUpdates));
         Assert.assertNull(updated.getBLOB());
+    }
+
+    @Test
+    public void testUpdateOfNonMigratingDoc() {
+        // NoMigrationSchema.json has `enableMigrations: false` in it. This means we explicitly opt-out of Dynamap schema
+        // migrations and, importantly, the conditional check that otherwise happens automatically on every document update
+        // to check the current schema version.
+        // This test exists to test for a bug we were seeing that would happen when:
+        // 1. We define a schema with `enableMigrations: false`
+        // 2. We try to update an instance of the code generated document.
+        // 3. We get an unexpected ConditionalCheckException that was a result of the generated code still performing
+        //    the conditional check on the schema version even though the schema version was no longer present in the
+        //    rest of the generated code.
+        final String DOC_ID = "1";
+        NoMigrationDocBean doc = new NoMigrationDocBean(DOC_ID);
+        dynamap.save(new SaveParams<>(doc));
+
+        NoMigrationDocBean savedDoc = dynamap.getObject(new GetObjectParams<>(new GetObjectRequest<>(NoMigrationDocBean.class).withHashKeyValue(DOC_ID)));
+        Assert.assertNull(savedDoc.getName());
+
+        // Save with no conditions
+        NoMigrationDocUpdates docUpdates = savedDoc.createUpdates();
+        docUpdates.setName("Granny");
+        dynamap.update(new UpdateParams<>(docUpdates));
+
+        savedDoc = dynamap.getObject(new GetObjectParams<>(new GetObjectRequest<>(NoMigrationDocBean.class).withHashKeyValue(DOC_ID)));
+        Assert.assertEquals(savedDoc.getName(), "Granny");
+
+        // Save with an equals condition
+        docUpdates = savedDoc.createUpdates();
+        docUpdates.setName(null); // Now set it back to null again
+        DynamoExpressionBuilder expression = docUpdates.getExpressionBuilder();
+        expression.addCheckFieldValueCondition(null, NoMigrationDoc.NAME_FIELD, "Granny", DynamoExpressionBuilder.ComparisonOperator.EQUALS); // Update should only happen if name is null
+        dynamap.update(new UpdateParams<>(docUpdates));
+
+        savedDoc = dynamap.getObject(new GetObjectParams<>(new GetObjectRequest<>(NoMigrationDocBean.class).withHashKeyValue(DOC_ID)));
+        Assert.assertNull(savedDoc.getName());
     }
 
     int seq = 0;

--- a/src/test/resources/NoMigrationSchema.json
+++ b/src/test/resources/NoMigrationSchema.json
@@ -1,0 +1,29 @@
+{
+  "tables": [
+    {
+      "table": "NoMigrationTable",
+      "package": "com.n3twork.dynamap.test",
+      "type": "NoMigrationDoc",
+      "version": 1,
+      "enableMigrations": false,
+      "hashKey": "id",
+      "types": [
+        {
+          "name": "NoMigrationDoc",
+          "fields": [
+            {
+              "name": "id",
+              "dynamoName": "id",
+              "type": "String"
+            },
+            {
+              "name": "name",
+              "dynamoName": "n",
+              "type": "String"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Without this patch, we get the following bad behavior:
1. Create a schema with `enableMigrations: false`
2. Try to perform an update on one of the resulting documents.
3. Update will fail with a mysterious `ConditionalCheckException`
This turns out to be a simple codegen issue: we were not removing the automatic condition check Dynamap provides for the schema version field in this case where the use opts out of schema migrations.
The diff is pretty small... the provided test case fails without the codegen patch.