### PR TITLE
CreateTable requests can be customized

### DIFF
--- a/src/main/java/com/n3twork/dynamap/Dynamap.java
+++ b/src/main/java/com/n3twork/dynamap/Dynamap.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class Dynamap {
@@ -84,10 +85,18 @@ public class Dynamap {
     }
 
     public void createTables(boolean deleteIfExists) {
-        createTables(deleteIfExists, 1, 1);
+        createTables(deleteIfExists, 1, 1, request -> {});
+    }
+
+    public void createTables(boolean deleteIfExists, Consumer<CreateTableRequest> requestTransformer) {
+        createTables(deleteIfExists, 1, 1, requestTransformer);
     }
 
     public void createTables(boolean deleteIfExists, long readProvisioning, long writeProvisioning) {
+        createTables(deleteIfExists, readProvisioning, writeProvisioning, request -> {});
+    }
+
+    public void createTables(boolean deleteIfExists, long readProvisioning, long writeProvisioning, Consumer<CreateTableRequest> requestTransformer) {
         for (TableDefinition tableDefinition : schemaRegistry.getSchema().getTableDefinitions()) {
 
             ArrayList<AttributeDefinition> attributeDefinitions = new ArrayList<>();
@@ -192,6 +201,8 @@ public class Dynamap {
             if (localSecondaryIndexes.size() > 0) {
                 request = request.withLocalSecondaryIndexes(localSecondaryIndexes);
             }
+
+            requestTransformer.accept(request);
 
             if (deleteIfExists) {
                 TableUtils.deleteTableIfExists(amazonDynamoDB, new DeleteTableRequest().withTableName(tableDefinition.getTableName(prefix)));

--- a/src/test/java/com/n3twork/dynamap/DynamapCreateTableTest.java
+++ b/src/test/java/com/n3twork/dynamap/DynamapCreateTableTest.java
@@ -1,0 +1,58 @@
+package com.n3twork.dynamap;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.local.embedded.DynamoDBEmbedded;
+import com.amazonaws.services.dynamodbv2.model.BillingMode;
+import com.amazonaws.services.dynamodbv2.model.DescribeTableRequest;
+import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndex;
+import com.amazonaws.services.dynamodbv2.model.TableDescription;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class DynamapCreateTableTest {
+    private final static ObjectMapper objectMapper = new ObjectMapper();
+
+    private AmazonDynamoDB ddb;
+    private Dynamap dynamap;
+
+    @BeforeClass
+    public void setUpClass() {
+        System.setProperty("sqlite4java.library.path", "native-libs");
+        ddb = DynamoDBEmbedded.create().amazonDynamoDB();
+    }
+
+    @BeforeMethod
+    public void setUp() {
+        SchemaRegistry schemaRegistry = new SchemaRegistry(getClass().getResourceAsStream("/TestSchema.json"));
+        dynamap = new Dynamap(ddb, schemaRegistry).withPrefix("create-table-test.").withObjectMapper(objectMapper);
+    }
+
+    @Test
+    public void testCreateProvisionedTable() {
+        dynamap.createTables(true, 10, 11);
+        TableDescription description = ddb.describeTable(new DescribeTableRequest().withTableName("create-table-test.Test")).getTable();
+        assertEquals((long) description.getProvisionedThroughput().getReadCapacityUnits(), 10);
+        assertEquals((long) description.getProvisionedThroughput().getWriteCapacityUnits(), 11);
+    }
+
+    @Test
+    public void testCreatePayPerRequestTable() {
+        dynamap.createTables(true, request -> {
+            request
+                    .withBillingMode(BillingMode.PAY_PER_REQUEST)
+                    .withProvisionedThroughput(null);
+
+            if (request.getGlobalSecondaryIndexes() != null) {
+                for (GlobalSecondaryIndex gsi : request.getGlobalSecondaryIndexes()) {
+                    gsi.withProvisionedThroughput(null);
+                }
+            }
+        });
+        TableDescription description = ddb.describeTable(new DescribeTableRequest().withTableName("create-table-test.Test")).getTable();
+        assertEquals(description.getBillingModeSummary().getBillingMode(), "PAY_PER_REQUEST");
+    }
+}


### PR DESCRIPTION
I had a need to create pay-per-request tables depending on the environment. The proposed solution in this pull request is to provide an additional argument to the `createTable` overloads that allows the caller to modify the create-table request that Dynamap is about to send.