### PR TITLE
Use correct syntax for non-equality comparison operator

### DIFF
--- a/src/main/java/com/n3twork/dynamap/DynamoExpressionBuilder.java
+++ b/src/main/java/com/n3twork/dynamap/DynamoExpressionBuilder.java
@@ -48,7 +48,7 @@ public class DynamoExpressionBuilder {
 
     public enum ComparisonOperator {
 
-        EQUALS("="), NOT_EQUALS("!="), LESS_THAN("<"), LESS_THAN_EQUAL_TO("<="), GREATHER_THAN(">"), GREATER_THAN_EQUAL_TO(">=");
+        EQUALS("="), NOT_EQUALS("<>"), LESS_THAN("<"), LESS_THAN_EQUAL_TO("<="), GREATHER_THAN(">"), GREATER_THAN_EQUAL_TO(">=");
 
         private final String value;
 


### PR DESCRIPTION
- Corrected operator symbol from "!=" to "<>" as per: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html

This fixes: https://github.com/N3TWORK/dynamap/issues/71