### PR TITLE
Support for `ReturnValuesOnConditionCheckFailure`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>DynamoDBLocal</artifactId>
-            <version>1.13.1</version>
+            <version>1.23.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/n3twork/dynamap/DeleteRequest.java
+++ b/src/main/java/com/n3twork/dynamap/DeleteRequest.java
@@ -16,6 +16,8 @@
 
 package com.n3twork.dynamap;
 
+import com.amazonaws.services.dynamodbv2.model.ReturnValuesOnConditionCheckFailure;
+
 import java.util.Map;
 
 public class DeleteRequest<T extends DynamapRecordBean> {
@@ -26,6 +28,7 @@ public class DeleteRequest<T extends DynamapRecordBean> {
     private Map<String, Object> values;
     private Map<String, String> names;
     private String suffix;
+    private ReturnValuesOnConditionCheckFailure returnValuesOnConditionCheckFailure = ReturnValuesOnConditionCheckFailure.NONE;
 
     public DeleteRequest(Class<T> resultClass) {
         this.resultClass = resultClass;
@@ -47,6 +50,10 @@ public class DeleteRequest<T extends DynamapRecordBean> {
         return this;
     }
 
+    public DeleteRequest<T> withReturnValuesOnConditionalCheckFailure(ReturnValuesOnConditionCheckFailure returnValuesOnConditionCheckFailure) {
+        this.returnValuesOnConditionCheckFailure = returnValuesOnConditionCheckFailure;
+        return this;
+    }
 
     public DeleteRequest<T> withNames(Map<String, String> names) {
         this.names = names;
@@ -78,6 +85,8 @@ public class DeleteRequest<T extends DynamapRecordBean> {
     public String getConditionExpression() {
         return conditionExpression;
     }
+
+    public ReturnValuesOnConditionCheckFailure getReturnValuesOnConditionCheckFailure() { return returnValuesOnConditionCheckFailure; }
 
     public Map<String, Object> getValues() {
         return values;

--- a/src/main/java/com/n3twork/dynamap/SaveParams.java
+++ b/src/main/java/com/n3twork/dynamap/SaveParams.java
@@ -16,6 +16,8 @@
 
 package com.n3twork.dynamap;
 
+import com.amazonaws.services.dynamodbv2.model.ReturnValuesOnConditionCheckFailure;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +32,8 @@ public class SaveParams<T extends DynamapRecordBean> {
     private String suffix;
     private Map<String, Object> values;
     private Map<String, String> names;
-    List<String> conditionExpressions = new ArrayList<>();
+    private List<String> conditionExpressions = new ArrayList<>();
+    private ReturnValuesOnConditionCheckFailure returnValuesOnConditionCheckFailure = ReturnValuesOnConditionCheckFailure.NONE;
 
     private SaveParams() {
     }
@@ -64,6 +67,10 @@ public class SaveParams<T extends DynamapRecordBean> {
         return this;
     }
 
+    public SaveParams<T> withReturnValuesOnConditionCheckFailure(ReturnValuesOnConditionCheckFailure returnValuesOnConditionCheckFailure) {
+        this.returnValuesOnConditionCheckFailure = returnValuesOnConditionCheckFailure;
+        return this;
+    }
 
     public SaveParams<T> withNames(Map<String, String> names) {
         this.names = names;
@@ -109,4 +116,6 @@ public class SaveParams<T extends DynamapRecordBean> {
     public List<String> getConditionExpressions() {
         return conditionExpressions;
     }
+
+    public ReturnValuesOnConditionCheckFailure getReturnValuesOnConditionCheckFailure() { return returnValuesOnConditionCheckFailure; }
 }

--- a/src/main/java/com/n3twork/dynamap/UpdateParams.java
+++ b/src/main/java/com/n3twork/dynamap/UpdateParams.java
@@ -16,12 +16,15 @@
 
 package com.n3twork.dynamap;
 
+import com.amazonaws.services.dynamodbv2.model.ReturnValuesOnConditionCheckFailure;
+
 public class UpdateParams<T extends DynamapPersisted<? extends RecordUpdates<T>>> {
 
     private RecordUpdates<T> updates;
     private DynamoRateLimiter writeLimiter;
     private String suffix;
     private DynamapReturnValue dynamapReturnValue = DynamapReturnValue.ALL_NEW;
+    private ReturnValuesOnConditionCheckFailure returnValuesOnConditionCheckFailure = ReturnValuesOnConditionCheckFailure.NONE;
 
     private UpdateParams() {
     }
@@ -45,6 +48,11 @@ public class UpdateParams<T extends DynamapPersisted<? extends RecordUpdates<T>>
         return this;
     }
 
+    public UpdateParams<T> withReturnValuesOnConditionCheckFailure(ReturnValuesOnConditionCheckFailure returnValuesOnConditionCheckFailure) {
+        this.returnValuesOnConditionCheckFailure = returnValuesOnConditionCheckFailure;
+        return this;
+    }
+
     ////////
 
 
@@ -63,4 +71,6 @@ public class UpdateParams<T extends DynamapPersisted<? extends RecordUpdates<T>>
     public DynamapReturnValue getDynamapReturnValue() {
         return dynamapReturnValue;
     }
+
+    public ReturnValuesOnConditionCheckFailure getReturnValuesOnConditionCheckFailure() { return returnValuesOnConditionCheckFailure; }
 }

--- a/src/main/java/com/n3twork/dynamap/WriteConditionCheck.java
+++ b/src/main/java/com/n3twork/dynamap/WriteConditionCheck.java
@@ -1,5 +1,6 @@
 package com.n3twork.dynamap;
 
+import com.amazonaws.services.dynamodbv2.model.ReturnValuesOnConditionCheckFailure;
 import com.n3twork.dynamap.DynamapRecordBean;
 import com.n3twork.dynamap.DynamoExpressionBuilder;
 
@@ -8,12 +9,18 @@ public class WriteConditionCheck<T extends DynamapRecordBean> {
     private final DynamoExpressionBuilder dynamoExpressionBuilder;
     private final String hashKey;
     private final String rangeKey;
+    private ReturnValuesOnConditionCheckFailure returnValuesOnConditionCheckFailure = ReturnValuesOnConditionCheckFailure.NONE;
+
 
     public WriteConditionCheck(Class<T> beanClass, String hashKey, String rangeKey) {
         this.beanClass = beanClass;
         this.dynamoExpressionBuilder = new DynamoExpressionBuilder(0);
         this.hashKey = hashKey;
         this.rangeKey = rangeKey;
+    }
+
+    public void setReturnValuesOnConditionCheckFailure(ReturnValuesOnConditionCheckFailure returnValuesOnConditionCheckFailure) {
+        this.returnValuesOnConditionCheckFailure = returnValuesOnConditionCheckFailure;
     }
 
     public Class<T> getBeanClass() {
@@ -30,5 +37,9 @@ public class WriteConditionCheck<T extends DynamapRecordBean> {
 
     public String getRangeKey() {
         return rangeKey;
+    }
+
+    public ReturnValuesOnConditionCheckFailure getReturnValuesOnConditionCheckFailure() {
+        return returnValuesOnConditionCheckFailure;
     }
 }

--- a/src/test/java/com/n3twork/dynamap/DynamapTxTest.java
+++ b/src/test/java/com/n3twork/dynamap/DynamapTxTest.java
@@ -21,10 +21,9 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.local.embedded.DynamoDBEmbedded;
-import com.amazonaws.services.dynamodbv2.model.CancellationReason;
-import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
-import com.amazonaws.services.dynamodbv2.model.TransactionCanceledException;
+import com.amazonaws.services.dynamodbv2.model.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.n3twork.dynamap.test.Player;
 import com.n3twork.dynamap.test.PlayerBean;
 import com.n3twork.dynamap.test.PlayerUpdates;
 import org.testng.annotations.BeforeMethod;
@@ -32,6 +31,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.testng.Assert.*;
 
@@ -189,5 +189,147 @@ public class DynamapTxTest {
         assertEquals(result.get(0), p1);
         assertNull(result.get(1));
         assertEquals(result.get(2), p2);
+    }
+
+    @Test
+    public void testSaveTx_ReturnsValuesOnFailure() {
+        PlayerBean p1 = new PlayerBean("playerOne", "Player One", PlayerBean.SCHEMA_VERSION);
+
+        // Initial create should succeed
+        WriteTx initialCreateTx = dynamap.newWriteTx();
+        initialCreateTx.save(new SaveParams<>(p1));
+        initialCreateTx.exec();
+
+        PlayerBean playerOneRead = dynamap.getObject(new GetObjectParams<>(new GetObjectRequest<>(PlayerBean.class).withHashKeyValue("playerOne")));
+        assertNotNull(playerOneRead);
+        assertEquals(playerOneRead, p1);
+
+        // Player exists, so this second save should fail with when we disable overwriting
+        WriteTx secondCreateTx = dynamap.newWriteTx();
+        SaveParams<PlayerBean> saveParams = new SaveParams<>(p1).withDisableOverwrite(true); // this should fail
+        saveParams.withReturnValuesOnConditionCheckFailure(ReturnValuesOnConditionCheckFailure.ALL_OLD); // request all document attributes on failure
+        secondCreateTx.save(saveParams);
+        TransactionCanceledException thrown = null;
+        try {
+            secondCreateTx.exec();
+        } catch(TransactionCanceledException e) {
+            thrown = e;
+        }
+        assertNotNull(thrown);
+        assertEquals(thrown.getCancellationReasons().size(), 1);
+        assertEquals(thrown.getCancellationReasons().get(0).getCode(), "ConditionalCheckFailed");
+        Map<String, AttributeValue> oldItem = thrown.getCancellationReasons().get(0).getItem();
+        assertNotNull(oldItem);
+        assertEquals(oldItem.get(PlayerBean.ID_FIELD).getS(), p1.getId()); // all document attributes were returned as requested
+
+        // Overwrite will work when we don't explicitly disable overwriting
+        WriteTx thirdCreateTx = dynamap.newWriteTx();
+        thirdCreateTx.save(new SaveParams<>(p1));
+
+        // delete and confirm.
+        dynamap.delete(new DeleteRequest<>(PlayerBean.class).withHashKeyValue(p1.getId()));
+        playerOneRead = dynamap.getObject(new GetObjectParams<>(new GetObjectRequest<>(PlayerBean.class).withHashKeyValue(p1.getId())));
+        assertNull(playerOneRead);
+    }
+
+    @Test
+    public void testUpdateTx_ReturnsValuesOnFailure() {
+        PlayerBean p1 = new PlayerBean("playerOne", "Player One", PlayerBean.SCHEMA_VERSION);
+
+        // Create p1.
+        dynamap.save(new SaveParams<>(p1));
+
+        PlayerBean playerOneRead = dynamap.getObject(new GetObjectParams<>(new GetObjectRequest<>(PlayerBean.class).withHashKeyValue(p1.getId())));
+        assertNotNull(playerOneRead);
+        assertEquals(playerOneRead, p1);
+
+        // Update p1 in a transaction.
+        PlayerUpdates playerOneUpdates = playerOneRead.createUpdates();
+        playerOneUpdates.setName("I am Player One");
+        playerOneUpdates.getExpressionBuilder().addAttributeNotExistsCondition(PlayerBean.ID_FIELD); // this should fail
+
+        WriteTx tx = dynamap.newWriteTx();
+        UpdateParams<Player> updateParams = new UpdateParams<>(playerOneUpdates);
+        updateParams.withReturnValuesOnConditionCheckFailure(ReturnValuesOnConditionCheckFailure.ALL_OLD); // request all document attributes on failure
+        tx.update(updateParams);
+        TransactionCanceledException thrown = null;
+        try {
+            tx.exec();
+        } catch(TransactionCanceledException e) {
+            thrown = e;
+        }
+        assertNotNull(thrown);
+        assertEquals(thrown.getCancellationReasons().size(), 1);
+        assertEquals(thrown.getCancellationReasons().get(0).getCode(), "ConditionalCheckFailed");
+        Map<String, AttributeValue> oldItem = thrown.getCancellationReasons().get(0).getItem();
+        assertNotNull(oldItem);
+        assertEquals(oldItem.get(PlayerBean.ID_FIELD).getS(), p1.getId()); // all document attributes were returned as requested
+
+        // delete and confirm.
+        dynamap.delete(new DeleteRequest<>(PlayerBean.class).withHashKeyValue(p1.getId()));
+        playerOneRead = dynamap.getObject(new GetObjectParams<>(new GetObjectRequest<>(PlayerBean.class).withHashKeyValue(p1.getId())));
+        assertNull(playerOneRead);
+    }
+
+    @Test
+    public void testWriteCondition_ReturnsValuesOnFailure() {
+        PlayerBean p1 = new PlayerBean("playerOne", "Player One", PlayerBean.SCHEMA_VERSION);
+
+        // save p1
+        dynamap.save(new SaveParams<>(p1));
+
+        // Attempt a doomed WriteCondition in a Tx
+        WriteConditionCheck<PlayerBean> writeConditionCheck = new WriteConditionCheck<>(PlayerBean.class, p1.getId(), null);
+        writeConditionCheck.getDynamoExpressionBuilder().addAttributeNotExistsCondition(PlayerBean.ID_FIELD); // this should fail
+        writeConditionCheck.setReturnValuesOnConditionCheckFailure(ReturnValuesOnConditionCheckFailure.ALL_OLD); // request all document attributes on failure
+
+        WriteTx tx = dynamap.newWriteTx();
+        tx.condition(writeConditionCheck);
+        TransactionCanceledException thrown = null;
+        try {
+            tx.exec();
+        } catch(TransactionCanceledException e) {
+            thrown = e;
+        }
+        assertNotNull(thrown);
+        assertEquals(thrown.getCancellationReasons().size(), 1);
+        assertEquals(thrown.getCancellationReasons().get(0).getCode(), "ConditionalCheckFailed");
+        Map<String, AttributeValue> oldItem = thrown.getCancellationReasons().get(0).getItem();
+        assertNotNull(oldItem);
+        assertEquals(oldItem.get(PlayerBean.ID_FIELD).getS(), p1.getId()); // all document attributes were returned as requested
+    }
+
+    @Test
+    public void testDeleteTx_ReturnsValuesOnFailure() {
+        PlayerBean p1 = new PlayerBean("playerOne", "Player One", PlayerBean.SCHEMA_VERSION);
+
+        // Create p1.
+        dynamap.save(new SaveParams<>(p1));
+
+        // Delete p1 in a tx with a condition that's doomed to fail.
+        WriteTx deleteWithCondition = dynamap.newWriteTx();
+
+        DeleteRequest<PlayerBean> deleteRequest = new DeleteRequest<>(PlayerBean.class).withHashKeyValue(p1.getId());
+        deleteRequest.withConditionExpression(String.format("attribute_not_exists(%s)", PlayerBean.ID_FIELD)); // this should fail
+        deleteRequest.withReturnValuesOnConditionalCheckFailure(ReturnValuesOnConditionCheckFailure.ALL_OLD); // request all document attributes on failure
+
+        deleteWithCondition.delete(deleteRequest);
+        TransactionCanceledException thrown = null;
+        try {
+            deleteWithCondition.exec();
+        } catch( TransactionCanceledException e ) {
+            thrown = e;
+        }
+        assertNotNull(thrown);
+        assertEquals(thrown.getCancellationReasons().size(), 1);
+        assertEquals(thrown.getCancellationReasons().get(0).getCode(), "ConditionalCheckFailed");
+        Map<String, AttributeValue> oldItem = thrown.getCancellationReasons().get(0).getItem();
+        assertNotNull(oldItem);
+        assertEquals(oldItem.get(PlayerBean.ID_FIELD).getS(), p1.getId()); // all document attributes were returned as requested
+
+        // delete and confirm
+        dynamap.delete(new DeleteRequest<>(PlayerBean.class).withHashKeyValue(p1.getId()));
+        PlayerBean playerOneRead = dynamap.getObject(new GetObjectParams<>(new GetObjectRequest<>(PlayerBean.class).withHashKeyValue(p1.getId())));
+        assertNull(playerOneRead);
     }
 }


### PR DESCRIPTION
* Upgrade to DynamoDBLocal:1.23.0 (latest, supports arm processors)
* Expose `ReturnValuesOnConditionCheckFailure` for Save/Delete/Update requests in transactions
* Fix longstanding bug: Condition expressions were not being registered for Deletes in transactions