### PR TITLE
Add support for byte[] in Lists for Dynamo updates

### DIFF
--- a/src/main/java/com/n3twork/dynamap/DynamoExpressionBuilder.java
+++ b/src/main/java/com/n3twork/dynamap/DynamoExpressionBuilder.java
@@ -31,7 +31,7 @@ public class DynamoExpressionBuilder {
 
     private ObjectMapper objectMapper;
 
-    private static final Set<String> SUPPORTED_JAVA_TYPES = ImmutableSet.of("java.lang.Integer", "java.lang.Long", "java.lang.Float", "java.lang.Double", "java.lang.Number", "java.lang.BigDecimal", "java.lang.String");
+    private static final Set<String> SUPPORTED_JAVA_TYPES = ImmutableSet.of("java.lang.Integer", "java.lang.Long", "java.lang.Float", "java.lang.Double", "java.lang.Number", "java.lang.BigDecimal", "java.lang.String", "[B");
 
     private final List<String> addSection = new ArrayList<>();
     private final List<String> setSection = new ArrayList<>();

--- a/src/test/java/com/n3twork/dynamap/DynamapTest.java
+++ b/src/test/java/com/n3twork/dynamap/DynamapTest.java
@@ -473,6 +473,41 @@ public class DynamapTest {
     }
 
     @Test
+    public void testListOfByteArrays() {
+        NestedTypeBean nested = createNestedTypeBean();
+        TestDocumentBean doc = createTestDocumentBean(nested);
+        dynamap.save(new SaveParams<>(doc));
+
+        doc = dynamap.getObject(createGetObjectParams(doc));
+        Assert.assertEquals(doc.getListOfByteArrays().size(), 0);
+        TestDocumentUpdates updates = doc.createUpdates();
+        updates.addListOfByteArraysItem("My test bytes".getBytes());
+        dynamap.update(new UpdateParams<>(updates));
+        doc = dynamap.getObject(createGetObjectParams(doc));
+        Assert.assertEquals(doc.getListOfByteArrays().size(), 1);
+        Assert.assertEquals(new String(doc.getListOfByteArrays().get(0), StandardCharsets.UTF_8), "My test bytes");
+
+        updates = doc.createUpdates();
+        updates.addListOfByteArraysItem("My test bytes 1".getBytes());
+        updates.addListOfByteArraysItem("My test bytes 2".getBytes());
+        Assert.assertEquals(updates.getListOfByteArrays().size(), 3);
+        dynamap.update(new UpdateParams<>(updates));
+        doc = dynamap.getObject(createGetObjectParams(doc));
+        Assert.assertEquals(doc.getListOfByteArrays().size(), 3);
+        Assert.assertEquals(new String(doc.getListOfByteArrays().get(0), StandardCharsets.UTF_8), "My test bytes");
+        Assert.assertEquals(new String(doc.getListOfByteArrays().get(1), StandardCharsets.UTF_8), "My test bytes 1");
+        Assert.assertEquals(new String(doc.getListOfByteArrays().get(2), StandardCharsets.UTF_8), "My test bytes 2");
+
+        updates = doc.createUpdates();
+        updates.addListOfByteArraysItem("My test bytes 1 ".getBytes());
+        updates.clearListOfByteArrays();
+        Assert.assertEquals(updates.getListOfByteArrays().size(), 0);
+        dynamap.update(new UpdateParams<>(updates));
+        doc = dynamap.getObject(createGetObjectParams(doc));
+        Assert.assertEquals(doc.getListOfByteArrays().size(), 0);
+    }
+
+    @Test
     public void testGzipList() {
 
         NestedTypeBean nested = createNestedTypeBean();

--- a/src/test/resources/TestSchema.json
+++ b/src/test/resources/TestSchema.json
@@ -131,6 +131,12 @@
               "elementType": "Integer"
             },
             {
+              "name": "listOfByteArrays",
+              "dynamoName": "byteArrList",
+              "type": "List",
+              "elementType": "byte[]"
+            },
+            {
               "name": "notPersistedString",
               "dynamoName": "notPersistedStr",
               "type": "String",


### PR DESCRIPTION
This adds support for byte[] nested within lists when performing an update